### PR TITLE
refactor(template): Update template ConfigMap name and handling in Omni toolkit

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,8 @@
             "request": "launch",
             "mode": "auto",
             "program": "cmd/main.go",
+            "dlvFlags": ["--check-go-version=false"],
+            "env": {"KUBECONFIG": "/Users/andy/.kube/config"},
         }
     ]
 }

--- a/api/v1alpha1/devenv_types.go
+++ b/api/v1alpha1/devenv_types.go
@@ -55,6 +55,7 @@ type DevenvSpec struct {
 	CtrlSelector   string     `json:"ctrlSelector,omitempty"`
 	GpuSelector    string     `json:"gpuSelector,omitempty"`
 	Zone           string     `json:"zone,omitempty"`
+	TemplateCM     string     `json:"templateCM,omitempty"`
 }
 
 // DevenvStatus defines the observed state of Devenv

--- a/config/crd/bases/tanuu.dev_devenvs.yaml
+++ b/config/crd/bases/tanuu.dev_devenvs.yaml
@@ -69,6 +69,8 @@ spec:
                 type: string
               talosVersion:
                 type: string
+              templateCM:
+                type: string
               workerReplicas:
                 type: integer
               workerSelector:

--- a/config/samples/tanuu.dev_v1alpha1_devenv.yaml
+++ b/config/samples/tanuu.dev_v1alpha1_devenv.yaml
@@ -4,18 +4,20 @@ metadata:
   labels:
     app.kubernetes.io/name: tanuu-operator
     app.kubernetes.io/managed-by: kustomize
-  name: demo-platform-workshop
+  name: andy-test
 spec:
-  name: "demo-platform-workshop"
+  name: "andy-test"
   cloudProvider: "google"
-  workerReplicas: 2
+  workerReplicas: 3
   ctrlReplicas: 1
   gpuReplicas: 0
   k8sVersion: "v1.29.4"
   talosVersion: "v1.7.6"
   zone: "europe-north1-c"
   # The following fields are optional
-  workerSelector: "base-176"
-  ctrlSelector: "base-176"
-  gpuSelector: "gpu-176"
-  
+  # workerSelector: "base-176"
+  # ctrlSelector: "base-176"
+  # gpuSelector: "gpu-176"
+  # # This is the name of configmap that contains the talos cluster config template
+  # # generally, don't touch this field, or leave it out completely.
+  templateCM: "test-cluster"  

--- a/internal/controller/toolkit_controller.go
+++ b/internal/controller/toolkit_controller.go
@@ -174,7 +174,7 @@ func (r *DevenvReconciler) createKubeConfig(ctx context.Context, ctrlclient k8cl
 	// Define the namespaced name to look up the ConfigMap
 	namespacedName := types.NamespacedName{
 		Namespace: "tanuu-system",
-		Name:      "cluster",
+		Name:      "tanuu-operator",
 	}
 	// Get the ConfigMap
 	if err := ctrlclient.Get(ctx, namespacedName, configMap); err != nil {


### PR DESCRIPTION
Updated the ConfigMap name and handling in the Omni toolkit to use the
custom template specified in the Devenv spec. Also refactored the order
of reading from the ConfigMap.