### PR TITLE
add-kyverno-chainsaw: add basic assertion yamls for ephemeral cluster

### DIFF
--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-cluster_secret_store.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-cluster_secret_store.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: onepass
+status:
+  capabilities: ReadOnly 
+  conditions:
+    - message: store validated
+      reason: Valid 
+      status: "True"
+      type: Ready

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-daemonset-monitoring.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-daemonset-monitoring.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: prometheus-prometheus-node-exporter
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/instance: prometheus
+    app.kubernetes.io/name: prometheus-node-exporter
+status:
+  numberMisscheduled: 0
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: promtail 
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/instance: promtail
+    app.kubernetes.io/name: promtail
+status:
+  numberMisscheduled: 0

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-deployment-crossplane.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-deployment-crossplane.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: tailscale 
+status:
+  availableReplicas: 1
+  readyReplicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: crossplane-system
+  name:
+    (contains(@, 'function-go-templating')): true
+status:
+  availableReplicas: 1
+  readyReplicas: 1  
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: crossplane-system
+  name:
+    (contains(@, 'provider-kubernetes')): true
+status:
+  availableReplicas: 1
+  readyReplicas: 1  

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-deployment-tailscale.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-deployment-tailscale.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: operator
+  namespace: tailscale 
+status:
+  availableReplicas: 1
+  readyReplicas: 1

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-storageclasses.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-storageclasses.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: storage.k8s.io/v1 
+kind: StorageClass
+metadata:
+  name: longhorn
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+parameters:
+  dataLocality: disabled
+  fromBackup: ""
+  fsType: ext4
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "30"
+  unmapMarkSnapChainRemoved: ignored
+provisioner: driver.longhorn.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-svc-external-secrets.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-svc-external-secrets.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: central-onepass-connect
+  namespace: external-secrets
+  annotations:
+    tailscale.com/tailnet-ip: 100.83.181.82
+spec:
+#  (conditions[?external
+  #contains(externalName, ['ts-central-onepass-connect-[*].tailscale.svc.cluster.local']) 
+# (externalName: (contains(@, 'ts-central-onepass-connect'))): true
+#  externalName: 'ts-central-onepass-connect-[*].tailscale.svc.cluster.local' 
+#
+#regex_match(spec.externalName, '^ts-central-onepass-connect-[a-zA-Z0-9]+\.tailscale\.svc\.cluster\.local$')
+
+## Working2  
+#  externalName: 
+#    (starts_with(@, 'ts-central-onepass-connect')): true
+
+## Working2
+  externalName:
+    (contains(@, 'ts-central-onepass-connect')): true
+
+## Not working
+#  externalName:
+#    (pattern_match('ts-central-onepass-connect-*.tailcale.svc.cluster.local', @)): true

--- a/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-svc-monitoring.yaml
+++ b/kyverno-chainsaw/assertion-folder/ephemeral-cluster/expected-svc-monitoring.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: v1 
+kind: Service 
+metadata:
+  name: central-loki-gateway
+  namespace: monitoring
+  annotations:
+    tailscale.com/tailnet-ip: 100.118.222.118
+spec:
+#  externalName: ts-central-loki-gateway-nrbj8.tailscale.svc.cluster.local
+  externalName:
+    (contains(@, 'ts-central-loki-gateway')): true
+---
+apiVersion: v1 
+kind: Service
+metadata:
+  name: central-mimir-gateway
+  namespace: monitoring
+  annotations: 
+    tailscale.com/tailnet-ip: 100.105.169.59
+spec:
+#  externalName: ts-central-mimir-gateway-5kfn8.tailscale.svc.cluster.local 
+  externalName:
+    (contains(@, 'ts-central-mimir-gateway')): true

--- a/kyverno-chainsaw/chainsaw-config.yaml
+++ b/kyverno-chainsaw/chainsaw-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: chainsaw.kyverno.io/v1alpha2
+kind: Configuration
+metadata:
+  name: omni-ephemeral-config 
+spec:
+  #  namespace:
+  #    name: monitoring
+  cleanup:
+    skipDelete: false
+  execution:
+    failFast: true
+    parallel: 4
+

--- a/kyverno-chainsaw/chainsaw-test.yaml
+++ b/kyverno-chainsaw/chainsaw-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: quick-start
+spec:
+  steps:
+  - name: monitoring-ns/external_names
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-svc-monitoring.yaml
+  - name: external-secret-ns/cluster_secret_store 
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-cluster_secret_store.yaml
+  - name: external-secret-ns/external_names
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-svc-external-secrets.yaml
+  - name: monitoring-ns/daemonset
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-daemonset-monitoring.yaml
+  - name: longhorn-ns/storage_classes
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-storageclasses.yaml
+  - name: tailscale-ns/deployment
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-deployment-tailscale.yaml
+  - name: crossplane-ns/deployment
+    try:
+    - assert:
+        file: assertion-folder/ephemeral-cluster/expected-deployment-crossplane.yaml


### PR DESCRIPTION
This PR introduces assertion files of Kyverno-Chainsaw, designed to verify the basic status of platform tools in a deployed Omni ephemeral cluster.

Assertions will check:
- cluster-secret-store
- promtail
- prometheus
- crossplane
- tailscale
- longhorn

Added files were inspected by running at an omni cluster with this command "chainsaw test --config ./chainsaw-config.yaml".
The Tanuu-Operator, which creates and manages ephemeral clusters, has access to the kubeconfig of each newly created cluster. After creating a cluster, the operator can execute these tests using the corresponding kubeconfig.
